### PR TITLE
Make the warning a 1-time global

### DIFF
--- a/GUI/src/app/pages/generator/generator.component.ts
+++ b/GUI/src/app/pages/generator/generator.component.ts
@@ -153,7 +153,7 @@ export class GeneratorComponent implements OnInit {
     return filteredTabList;
   }
 
-  generateSeed(fromPatchFile: boolean = false, webRaceSeed: boolean = false, goalHintsConfirmed: boolean = false, noLogicConfirmed: boolean = false) {
+  generateSeed(fromPatchFile: boolean = false, webRaceSeed: boolean = false, goalHintsConfirmed: boolean = false) {
 
     this.generateSeedButtonEnabled = false;
     this.seedString = this.seedString.trim().replace(/[^a-zA-Z0-9_-]/g, '');
@@ -196,13 +196,15 @@ export class GeneratorComponent implements OnInit {
       return;
     }
 
-    if (!noLogicConfirmed && this.global.generator_settingsMap["logic_rules"] === "none") {
+    let noLogicConfirmed = localStorage.getItem("noLogicConfirmed")
+    if ((!noLogicConfirmed || noLogicConfirmed == "false") && this.global.generator_settingsMap["logic_rules"] === "none") {
       this.dialogService.open(ConfirmationWindowComponent, {
         autoFocus: true, closeOnBackdropClick: false, closeOnEsc: false, hasBackdrop: true, hasScroll: false, context: { dialogHeader: "No Logic Warning", dialogMessage: noLogicErrorText }
       }).onClose.subscribe(confirmed => {
         //User acknowledged possible unbeatability of no logic seeds
         if (confirmed) {
-          this.generateSeed(fromPatchFile, webRaceSeed, goalHintsConfirmed, true);
+          localStorage.setItem("noLogicConfirmed", JSON.stringify(true))
+          this.generateSeed(fromPatchFile, webRaceSeed, goalHintsConfirmed);
         }
       });
 

--- a/GUI/src/app/providers/GUIGlobal.ts
+++ b/GUI/src/app/providers/GUIGlobal.ts
@@ -1536,6 +1536,21 @@ export class GUIGlobal implements OnDestroy {
         throw err;
     }
 
+    //If no logic was intentionally enabled, warn user one time about the consequences
+    try {
+      let logicWarningSeen = localStorage.getItem("logicWarningSeen");
+
+      if ((!logicWarningSeen || logicWarningSeen == "false") && settingsFile["logic_rules"] == "none") {
+        localStorage.setItem("logicWarningSeen", JSON.stringify(true));
+        throw { error_no_logic_enabled: "Choosing no logic can require glitches to complete the seed or in very unlikely cases be unbeatable. Continue?" };
+      }
+    }
+    catch (err) { //Bubble through in case the warning should be displayed, ignore if local storage is not available
+      if (err.hasOwnProperty('error_no_logic_enabled'))
+        throw err;
+    }
+
+
     console.log(settingsFile);
     console.log("Race Seed:", raceSeed);
 

--- a/GUI/src/app/providers/GUIGlobal.ts
+++ b/GUI/src/app/providers/GUIGlobal.ts
@@ -1536,21 +1536,6 @@ export class GUIGlobal implements OnDestroy {
         throw err;
     }
 
-    //If no logic was intentionally enabled, warn user one time about the consequences
-    try {
-      let logicWarningSeen = localStorage.getItem("logicWarningSeen");
-
-      if ((!logicWarningSeen || logicWarningSeen == "false") && settingsFile["logic_rules"] == "none") {
-        localStorage.setItem("logicWarningSeen", JSON.stringify(true));
-        throw { error_no_logic_enabled: "Choosing no logic can require glitches to complete the seed or in very unlikely cases be unbeatable. Continue?" };
-      }
-    }
-    catch (err) { //Bubble through in case the warning should be displayed, ignore if local storage is not available
-      if (err.hasOwnProperty('error_no_logic_enabled'))
-        throw err;
-    }
-
-
     console.log(settingsFile);
     console.log("Race Seed:", raceSeed);
 


### PR DESCRIPTION
Removed the old logic assuming the warning had never been seen before and stored that in localStorage so it's only seen once rather than on every seed generation.