### PR TITLE
Move random starting item selection to world distribution

### DIFF
--- a/CI.py
+++ b/CI.py
@@ -57,7 +57,7 @@ def check_presets_formatting(fix_errors: bool = False) -> None:
         except Exception as e:
             error(f'Error in {preset_name} preset: {e}', False)
         for setting_name, setting in SettingInfos.setting_infos.items():
-            if setting_name != 'starting_items' and setting.shared and setting_name not in preset:
+            if setting_name not in ('starting_items', 'random_starting_items') and setting.shared and setting_name not in preset:
                 error(f'Missing setting {setting_name} in {preset_name} preset', False)
                 any_errors = True
     if any_errors:
@@ -80,7 +80,7 @@ def check_presets_formatting(fix_errors: bool = False) -> None:
             # sort the settings within each preset
             setting_name: preset[setting_name]
             for setting_name, setting in SettingInfos.setting_infos.items()
-            if setting_name != 'starting_items' and (setting.shared or setting_name == 'aliases') and setting_name in preset
+            if setting_name not in ('starting_items', 'random_starting_items') and (setting.shared or setting_name == 'aliases') and setting_name in preset
         }
         for preset_name, preset in presets.items()
     }

--- a/Hints.py
+++ b/Hints.py
@@ -1160,7 +1160,7 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: set[str]) 
                 and not location.locked
                 # exclude triforce pieces as it defeats the idea of a triforce hunt
                 and not location.item.name == 'Triforce Piece'
-                and not (location.name == 'Song from Impa' and 'Zeldas Letter' in world.settings.starting_items and 'Zeldas Letter' not in world.settings.shuffle_child_trade)
+                and not (location.name == 'Song from Impa' and ('Zeldas Letter' in world.settings.starting_items or 'Zeldas Letter' in world.distribution.random_starting_items) and 'Zeldas Letter' not in world.settings.shuffle_child_trade)
                 # Special cases where the item is only considered major for important checks hints
                 or location.item.name == 'Biggoron Sword'
                 or location.item.name == 'Double Defense'

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -1071,7 +1071,9 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
         item_groups['Junk'] = remove_junk_items
         world.distribution.distribution.search_groups['Junk'] = remove_junk_items
 
-    world.distribution.collect_starters(world.state)
+    world.distribution.collect_starters(world.state, world.distribution.starting_items)
+    if world.settings.add_random_starting_items:
+        world.distribution.collect_starters(world.state, world.distribution.random_starting_items)
 
     if not world.settings.shuffle_individual_ocarina_notes:
         for ocarina_button in ocarina_buttons:

--- a/Patches.py
+++ b/Patches.py
@@ -440,14 +440,16 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
     rewards_as_items = (
         world.settings.shuffle_dungeon_rewards not in ('vanilla', 'reward')
         or world.distribution.rewards_as_items
-        or any(name in reward_list and record.count for name, record in world.settings.starting_items.items())
+        or any((name in reward_list and record.count for name, record in world.settings.starting_items.items())
+               or (name in reward_list and record.count for name, record in world.distribution.random_starting_items.items()))
     )
     if rewards_as_items:
         rom.write_byte(rom.sym('REWARDS_AS_ITEMS'), 1)
     songs_as_items = (
         world.settings.shuffle_song_items != 'song'
         or world.distribution.songs_as_items
-        or any(name in song_list and record.count for name, record in world.settings.starting_items.items())
+        or any((name in song_list and record.count for name, record in world.settings.starting_items.items())
+               or (name in song_list and record.count for name, record in world.distribution.random_starting_items.items()))
         or world.settings.shuffle_individual_ocarina_notes
     )
     if songs_as_items:

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -281,11 +281,12 @@ class WorldDistribution:
         self.rewards_as_items: bool = False
         self.songs_as_items: bool = False
         self.skipped_locations: list[Location] = []
-        self.random_starting_items: dict[str, StarterRecord] = self.set_random_starting_items(self.distribution.settings.starting_items)
+        self.random_starting_items: dict[str, StarterRecord] = {}
         self.effective_starting_items: dict[str, StarterRecord] = {}
 
         src_dict = {} if src_dict is None else src_dict
         self.update(src_dict, update_all=True)
+        self.set_random_starting_items(self.distribution.settings.starting_items)
 
     def update(self, src_dict: dict[str, Any], update_all: bool = False) -> None:
         update_dict = {
@@ -575,7 +576,6 @@ class WorldDistribution:
             self.pool_add_item(pool, '#Bottle', -bottles)
 
         self.alter_starting_items(world, pool, self.starting_items)
-
         if world.settings.add_random_starting_items:
             self.alter_starting_items(world, pool, self.random_starting_items)
 
@@ -587,11 +587,11 @@ class WorldDistribution:
 
         return pool
 
-    def alter_starting_items(self, world: World, pool: list[str], starting_items_dict: dict[str, StarterRecord]) -> None:
+    def alter_starting_items(self, world: World, pool: list[str], starting_items: dict[str, StarterRecord]) -> None:
         bottle_matcher = self.pattern_matcher("#Bottle")
         adult_trade_matcher = self.pattern_matcher("#AdultTrade")
 
-        for item_name, record in starting_items_dict.items():
+        for item_name, record in starting_items.items():
             if bottle_matcher(item_name):
                 self.pool_remove_item([pool], "#Bottle", record.count)
             elif item_name in ('Pocket Egg', 'Pocket Cucco') and world.settings.adult_trade_shuffle:
@@ -641,8 +641,8 @@ class WorldDistribution:
             else:
                 self.item_pool[item.name] = ItemPoolRecord()
 
-    def collect_starters(self, state: State, item_dict: dict[str, StarterRecord]) -> None:
-        for (name, record) in item_dict.items():
+    def collect_starters(self, state: State, starting_items: dict[str, StarterRecord]) -> None:
+        for (name, record) in starting_items.items():
             for _ in range(record.count):
                 item = ItemFactory("Bottle" if name == "Bottle with Milk (Half)" else name, state.world)
                 state.collect(item)
@@ -1129,21 +1129,17 @@ class WorldDistribution:
         return available_items
 
     def set_random_starting_items(self, starting_items: dict[str, StarterRecord]) -> dict[str, StarterRecord]:
-        selected_items_dict = {}
-
-        if self.distribution.settings.add_random_starting_items:
+        if self.distribution.settings.add_random_starting_items and len(self.random_starting_items) == 0:
             item_pool = self.build_random_starting_items_pool(starting_items)
 
             if self.distribution.settings.add_random_starting_items < len(item_pool):
-                selected_items_list = random.sample(item_pool, self.distribution.settings.add_random_starting_items)
+                selected_items = random.sample(item_pool, self.distribution.settings.add_random_starting_items)
             else:
                 # if there's not enough items to select, just start with all items rather than erroring
-                selected_items_list = item_pool
+                selected_items = item_pool
 
-            for item in selected_items_list:
-                add_starting_item_with_ammo(selected_items_dict, item)
-
-        return selected_items_dict
+            for item in selected_items:
+                add_starting_item_with_ammo(self.random_starting_items, item)
 
     def configure_effective_starting_items(self, worlds: list[World], world: World) -> None:
         items = {item_name: record.copy() for item_name, record in self.starting_items.items()}

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -283,10 +283,11 @@ class WorldDistribution:
         self.skipped_locations: list[Location] = []
         self.random_starting_items: dict[str, StarterRecord] = {}
         self.effective_starting_items: dict[str, StarterRecord] = {}
+        
+        self.set_random_starting_items(self.distribution.settings.starting_items)
 
         src_dict = {} if src_dict is None else src_dict
         self.update(src_dict, update_all=True)
-        self.set_random_starting_items(self.distribution.settings.starting_items)
 
     def update(self, src_dict: dict[str, Any], update_all: bool = False) -> None:
         update_dict = {
@@ -1092,7 +1093,7 @@ class WorldDistribution:
                     item = 'Bottle'
                 else:
                     raise KeyError(f'invalid special item: {entry.item_name}')
-            if item not in item_groups['MajorItem'] and item not in ('Giants Knife', 'Biggoron Sword', 'Magic Bean'):
+            if item not in item_groups['MajorItem'] and item not in ('Giants Knife', 'Biggoron Sword', 'Magic Bean', 'Double Defense'):
                 continue
             if item in starting_items and entry.i >= self.distribution.settings.starting_items[item].count:
                 available_items.append(item)
@@ -1140,6 +1141,10 @@ class WorldDistribution:
 
             for item in selected_items:
                 add_starting_item_with_ammo(self.random_starting_items, item)
+
+            self.distribution.settings.random_starting_items.update({
+                (name, record.count) for name, record in self.random_starting_items.items()
+            })
 
     def configure_effective_starting_items(self, worlds: list[World], world: World) -> None:
         items = {item_name: record.copy() for item_name, record in self.starting_items.items()}

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -1142,10 +1142,6 @@ class WorldDistribution:
             for item in selected_items:
                 add_starting_item_with_ammo(self.random_starting_items, item)
 
-            self.distribution.settings.random_starting_items.update({
-                (name, record.count) for name, record in self.random_starting_items.items()
-            })
-
     def configure_effective_starting_items(self, worlds: list[World], world: World) -> None:
         items = {item_name: record.copy() for item_name, record in self.starting_items.items()}
 

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -281,6 +281,7 @@ class WorldDistribution:
         self.rewards_as_items: bool = False
         self.songs_as_items: bool = False
         self.skipped_locations: list[Location] = []
+        self.random_starting_items: dict[str, StarterRecord] = self.set_random_starting_items(self.distribution.settings.starting_items)
         self.effective_starting_items: dict[str, StarterRecord] = {}
 
         src_dict = {} if src_dict is None else src_dict
@@ -573,7 +574,24 @@ class WorldDistribution:
         else:
             self.pool_add_item(pool, '#Bottle', -bottles)
 
-        for item_name, record in self.starting_items.items():
+        self.alter_starting_items(world, pool, self.starting_items)
+
+        if world.settings.add_random_starting_items:
+            self.alter_starting_items(world, pool, self.random_starting_items)
+
+        junk_to_add = pool_size - len(pool)
+        if junk_to_add > 0:
+            self.pool_add_item(pool, "#Junk", junk_to_add)
+        else:
+            self.pool_remove_item([pool], "#Junk", -junk_to_add)
+
+        return pool
+
+    def alter_starting_items(self, world: World, pool: list[str], starting_items_dict: dict[str, StarterRecord]) -> None:
+        bottle_matcher = self.pattern_matcher("#Bottle")
+        adult_trade_matcher = self.pattern_matcher("#AdultTrade")
+
+        for item_name, record in starting_items_dict.items():
             if bottle_matcher(item_name):
                 self.pool_remove_item([pool], "#Bottle", record.count)
             elif item_name in ('Pocket Egg', 'Pocket Cucco') and world.settings.adult_trade_shuffle:
@@ -613,14 +631,6 @@ class WorldDistribution:
                 if item_name in item_groups["Song"]:
                     self.songs_as_items = True
 
-        junk_to_add = pool_size - len(pool)
-        if junk_to_add > 0:
-            self.pool_add_item(pool, "#Junk", junk_to_add)
-        else:
-            self.pool_remove_item([pool], "#Junk", -junk_to_add)
-
-        return pool
-
     def set_complete_itempool(self, pool: list[Item]) -> None:
         self.item_pool = {}
         for item in pool:
@@ -631,8 +641,8 @@ class WorldDistribution:
             else:
                 self.item_pool[item.name] = ItemPoolRecord()
 
-    def collect_starters(self, state: State) -> None:
-        for (name, record) in self.starting_items.items():
+    def collect_starters(self, state: State, item_dict: dict[str, StarterRecord]) -> None:
+        for (name, record) in item_dict.items():
             for _ in range(record.count):
                 item = ItemFactory("Bottle" if name == "Bottle with Milk (Half)" else name, state.world)
                 state.collect(item)
@@ -1068,9 +1078,79 @@ class WorldDistribution:
         )
 
         return data
+    
+    def build_random_starting_items_pool(self, starting_items: dict[str, StarterRecord]) -> list[str]:
+        available_items: list[StartingItems.Entry] = []
+
+        for entry in StartingItems.everything.values():
+            if not entry.special:
+                item = entry.item_name
+            else:
+                if entry.item_name == 'Rutos Letter' and self.distribution.settings.zora_fountain != 'open':
+                    item = 'Rutos Letter'
+                elif entry.item_name in ('Bottle', 'Rutos Letter'):
+                    item = 'Bottle'
+                else:
+                    raise KeyError(f'invalid special item: {entry.item_name}')
+            if item not in item_groups['MajorItem'] and item not in ('Giants Knife', 'Biggoron Sword', 'Magic Bean'):
+                continue
+            if item in starting_items and entry.i >= self.distribution.settings.starting_items[item].count:
+                available_items.append(item)
+            elif item not in starting_items:
+                available_items.append(item)
+
+        if ('Giants Knife' in starting_items and starting_items['Giants Knife'].count > 0 
+                or 'Biggoron Sword' in starting_items and starting_items['Biggoron Sword'].count > 0):
+            if 'Giants Knife' in available_items:
+                available_items.remove('Giants Knife')
+            if 'Biggoron Sword' in available_items:
+                available_items.remove('Biggoron Sword')
+        elif 'Giants Knife' in available_items and 'Biggoron Sword' in available_items:
+            available_items.remove(random.choice(('Giants Knife', 'Biggoron Sword')))
+        if self.distribution.settings.plant_beans and 'Magic Bean' in available_items:
+            available_items.remove('Magic Bean')
+        for item_name in child_trade_items:
+            if item_name not in self.distribution.settings.shuffle_child_trade and item_name in available_items:
+                available_items.remove(item_name)
+        for item_name in trade_items:
+            if item_name not in self.distribution.settings.adult_trade_start and item_name in available_items:
+                available_items.remove(item_name)
+        if not self.distribution.settings.adult_trade_shuffle:
+            # only allow one adult trade item
+            available_trade_items = [item_name for item_name in trade_items if item_name in available_items]
+            for item_name in available_trade_items:
+                available_items.remove(item_name)
+            if not any(starting_items[item_name].count > 0 for item_name in trade_items if item_name in starting_items):
+                available_items.append(random.choice(available_trade_items))
+        for item_name in ocarina_buttons:
+            if not self.distribution.settings.shuffle_individual_ocarina_notes and item_name in available_items:
+                available_items.remove(item_name)
+
+        return available_items
+
+    def set_random_starting_items(self, starting_items: dict[str, StarterRecord]) -> dict[str, StarterRecord]:
+        selected_items_dict = {}
+
+        if self.distribution.settings.add_random_starting_items:
+            item_pool = self.build_random_starting_items_pool(starting_items)
+
+            if self.distribution.settings.add_random_starting_items < len(item_pool):
+                selected_items_list = random.sample(item_pool, self.distribution.settings.add_random_starting_items)
+            else:
+                # if there's not enough items to select, just start with all items rather than erroring
+                selected_items_list = item_pool
+
+            for item in selected_items_list:
+                add_starting_item_with_ammo(selected_items_dict, item)
+
+        return selected_items_dict
 
     def configure_effective_starting_items(self, worlds: list[World], world: World) -> None:
         items = {item_name: record.copy() for item_name, record in self.starting_items.items()}
+
+        if world.settings.add_random_starting_items:
+            for name in self.random_starting_items:
+                add_starting_item_with_ammo(items, name)
 
         if world.settings.start_with_rupees:
             add_starting_item_with_ammo(items, 'Rupees', 999)
@@ -1284,56 +1364,7 @@ class Distribution:
                 # removing an extra 4 pieces in case of an odd number since there's 9*4 of them but only 8 containers
                 data['Piece of Heart'].count += 4 * math.ceil(num_hearts_to_collect / 2)
                 data['Heart Container'].count += math.floor(num_hearts_to_collect / 2)
-        # add random starting items
-        if self.settings.add_random_starting_items > 0:
-            available_items: list[StartingItems.Entry] = []
-            for entry in StartingItems.everything.values():
-                if not entry.special:
-                    item = entry.item_name
-                else:
-                    if entry.item_name == 'Rutos Letter' and self.settings.zora_fountain != 'open':
-                        item = 'Rutos Letter'
-                    elif entry.item_name in ('Bottle', 'Rutos Letter'):
-                        item = 'Bottle'
-                    else:
-                        raise KeyError(f'invalid special item: {entry.item_name}')
-                if entry.i >= data[item].count:
-                    available_items.append(item)
-
-            if data['Giants Knife'].count > 0 or data['Biggoron Sword'].count > 0:
-                if 'Giants Knife' in available_items:
-                    available_items.remove('Giants Knife')
-                if 'Biggoron Sword' in available_items:
-                    available_items.remove('Biggoron Sword')
-            elif 'Giants Knife' in available_items and 'Biggoron Sword' in available_items:
-                available_items.remove(random.choice(('Giants Knife', 'Biggoron Sword')))
-            if self.settings.plant_beans and 'Magic Bean' in available_items:
-                available_items.remove('Magic Bean')
-            for item_name in child_trade_items:
-                if item_name not in self.settings.shuffle_child_trade and item_name in available_items:
-                    available_items.remove(item_name)
-            for item_name in trade_items:
-                if item_name not in self.settings.adult_trade_start and item_name in available_items:
-                    available_items.remove(item_name)
-            if not self.settings.adult_trade_shuffle:
-                # only allow one adult trade item
-                available_trade_items = [item_name for item_name in trade_items if item_name in available_items]
-                for item_name in available_trade_items:
-                    available_items.remove(item_name)
-                if not any(data[item_name].count > 0 for item_name in trade_items):
-                    available_items.append(random.choice(available_trade_items))
-            for item_name in ocarina_buttons:
-                if not self.settings.shuffle_individual_ocarina_notes and item_name in available_items:
-                    available_items.remove(item_name)
-
-            if self.settings.add_random_starting_items < len(available_items):
-                selected_items = random.sample(available_items, self.settings.add_random_starting_items)
-            else:
-                # if there's not enough items to select, just start with all items rather than erroring
-                selected_items = available_items
-            for item_name in selected_items:
-                add_starting_item_with_ammo(data, item_name)
-        self.settings.starting_items = {item_name: record for item_name, record in data.items() if record.count != 0}
+        self.settings.starting_items = data
 
     def to_json(self, include_output: bool = True, spoiler: bool = True) -> dict[str, Any]:
         self_dict = {

--- a/Rules.py
+++ b/Rules.py
@@ -29,7 +29,8 @@ def set_rules(world: World) -> None:
             if location.type == 'Song':
                 # allow junk items, but songs must still have matching world
                 add_item_rule(location, lambda location, item:
-                    ((location.world.distribution.songs_as_items or any(name in song_list and record.count for name, record in world.settings.starting_items.items()))
+                    ((location.world.distribution.songs_as_items or any((name in song_list and record.count for name, record in world.settings.starting_items.items())
+                                                                        or (name in song_list and record.count for name, record in world.distribution.random_starting_items.items())))
                         and item.type != 'Song')
                     or (item.type == 'Song' and item.world.id == location.world.id))
             else:

--- a/SaveContext.py
+++ b/SaveContext.py
@@ -1711,7 +1711,7 @@ def write_settings_dependent_save_context_flags(save_context: SaveContext, world
         save_context.write_bits(0x0EDD, 0x01) # "Obtained Zelda's Letter"
         save_context.write_bits(0x0EDE, 0x02) # "Learned Zelda's Lullaby"
         save_context.write_permanent_flag(Scenes.HYRULE_CASTLE, FlagType.SWITCH, 0x3, 0x10) # "Moved crates to access the courtyard"
-    if 'Zeldas Letter' in world.distribution.starting_items:
+    if 'Zeldas Letter' in (world.distribution.starting_items, world.distribution.random_starting_items):
         if world.settings.open_kakariko != 'closed':
             save_context.write_bits(0x0F07, 0x40)  # "Spoke to Gate Guard About Mask Shop"
         if world.settings.complete_mask_quest:

--- a/SaveContext.py
+++ b/SaveContext.py
@@ -1711,7 +1711,7 @@ def write_settings_dependent_save_context_flags(save_context: SaveContext, world
         save_context.write_bits(0x0EDD, 0x01) # "Obtained Zelda's Letter"
         save_context.write_bits(0x0EDE, 0x02) # "Learned Zelda's Lullaby"
         save_context.write_permanent_flag(Scenes.HYRULE_CASTLE, FlagType.SWITCH, 0x3, 0x10) # "Moved crates to access the courtyard"
-    if 'Zeldas Letter' in (world.distribution.starting_items, world.distribution.random_starting_items):
+    if 'Zeldas Letter' in world.distribution.starting_items or 'Zeldas Letter' in world.distribution.random_starting_items:
         if world.settings.open_kakariko != 'closed':
             save_context.write_bits(0x0F07, 0x40)  # "Spoke to Gate Guard About Mask Shop"
         if world.settings.complete_mask_quest:

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3213,6 +3213,8 @@ class SettingInfos:
 
     starting_items = SettingInfoDict(None, None, True, {})
 
+    random_starting_items = SettingInfoDict(None, None, True, {})
+
     starting_equipment = SearchBox(
         gui_text       = "Starting Equipment",
         shared         = True,


### PR DESCRIPTION
I'm not entirely sure if this is what you meant by moving everything into `WorldDistribution`

This is kind of a mess, but the selected items are supposed to be added to `WorldDistribution` as the attribute `random_starting_items` initially, removed from the item pool in `alter_pool`, collected as starters in `collect_starters` and then added to `effective_starting_items` to later be given through `give_item`.

This isn't currently reflected in the spoiler though, even though the items are given in game so I don't really know what to do from there or if this is even feasible.